### PR TITLE
Psapi Patch for Window

### DIFF
--- a/src/server/wsgi_memory.c
+++ b/src/server/wsgi_memory.c
@@ -7,7 +7,9 @@
 
 #if defined(_WIN32)
 #include <windows.h>
+#define PSAPI_VERSION 1
 #include <psapi.h>
+#pragma comment(lib, "psapi.lib")
 
 #elif defined(__unix__) || defined(__unix) || defined(unix) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>


### PR DESCRIPTION
Reading over https://msdn.microsoft.com/en-us/library/windows/desktop/ms683219%28v=vs.85%29.aspx, the important part seems to be 

>Programs that must run on earlier versions of Windows as well as Windows 7 and later versions should always call this function as GetProcessMemoryInfo. To ensure correct resolution of symbols, add Psapi.lib to the TARGETLIBS macro and compile the program with -DPSAPI_VERSION=1. To use run-time dynamic linking, load Psapi.dll.

PSAPI_VERSION is apparently something you set, not check. And 1 is more universal than >=2

The ```#pragma comment(lib, "psapi.lib")``` line still baffles me... But I do NOT need add psapi.lib to the LDLIBS in the make files. So whatever this magic does, it 'adds psapi.lib in TARGETLIBS' and finds the correct psapi.lib. I suppose this feature exists so that you don't have to worry about accidentally linking to a psapi.lib that might be in your library path. **shrugs** You know this will find the visual studio psapi.lib, or as least that's how I interpreted the literature. If you decide you do not like this pragma, it can be removed and just have psapi.lib added to the LDLIBS in your common .mk files. This works too.

Here are two "forums" suggesting the solution I picked
https://social.msdn.microsoft.com/Forums/vstudio/en-US/573b1037-f0de-4817-8c54-3ebf623cf4e0/building?forum=vcgeneral
http://www.gamedev.net/topic/559505-vs-c-2008-exp-how-do-i-set-it-up-like-this/

https://msdn.microsoft.com/en-US/library/7f0aews7%28v=vs.90%29.aspx / https://msdn.microsoft.com/en-US/library/7f0aews7(v=vs.100).aspx doesn't REALLY explain ANYTHING about why this magical pragma IS this mystical "TARGETLIBS"

I did not investigate the psapi.dll path... I generally figure that's asking for potential trouble down the road.