### PR TITLE
Add Apache 2.4 access control syntax

### DIFF
--- a/docs/user-guides/quick-configuration-guide.rst
+++ b/docs/user-guides/quick-configuration-guide.rst
@@ -95,8 +95,12 @@ Apache, it will be necessary to tell Apache that files within that
 directory can be used. To do this the Directory directive must be used::
 
     <Directory /usr/local/www/wsgi-scripts>
+    # Apache 2.2
     Order allow,deny
     Allow from all
+    
+    # Apache 2.4
+    Require all granted
     </Directory>
 
 Note that it is highly recommended that the WSGI application script file in
@@ -126,15 +130,23 @@ therefore be something like::
         DocumentRoot /usr/local/www/documents
 
         <Directory /usr/local/www/documents>
+        # Apache 2.2
         Order allow,deny
         Allow from all
+        
+        # Apache 2.4
+        Require all granted
         </Directory>
 
         WSGIScriptAlias /myapp /usr/local/www/wsgi-scripts/myapp.wsgi
 
         <Directory /usr/local/www/wsgi-scripts>
+        # Apache 2.2
         Order allow,deny
         Allow from all
+        
+        # Apache 2.4
+        Require all granted
         </Directory>
 
     </VirtualHost>
@@ -184,15 +196,23 @@ therefore be something like::
         Alias /media/ /usr/local/www/documents/media/
 
         <Directory /usr/local/www/documents>
+        # Apache 2.2
         Order allow,deny
         Allow from all
+        
+        # Apache 2.4
+        Require all granted
         </Directory>
 
         WSGIScriptAlias / /usr/local/www/wsgi-scripts/myapp.wsgi
 
         <Directory /usr/local/www/wsgi-scripts>
+        # Apache 2.2
         Order allow,deny
         Allow from all
+        
+        # Apache 2.4
+        Require all granted
         </Directory>
 
     </VirtualHost>
@@ -255,8 +275,12 @@ therefore be something like::
         Alias /media/ /usr/local/www/documents/media/
 
         <Directory /usr/local/www/documents>
+        # Apache 2.2
         Order allow,deny
         Allow from all
+        
+        # Apache 2.4
+        Require all granted
         </Directory>
 
         WSGIDaemonProcess example.com processes=2 threads=15 display-name=%{GROUP}
@@ -265,8 +289,12 @@ therefore be something like::
         WSGIScriptAlias / /usr/local/www/wsgi-scripts/myapp.wsgi
 
         <Directory /usr/local/www/wsgi-scripts>
+        # Apache 2.2
         Order allow,deny
         Allow from all
+        
+        # Apache 2.4
+        Require all granted
         </Directory>
 
     </VirtualHost>


### PR DESCRIPTION
This supplements the syntax for access control, i.e.,

```
Order allow,deny
Allow from all
```

To Apache 2.4's syntax:

```
Require all granted
```

See: https://httpd.apache.org/docs/trunk/upgrading.html#run-time