### PR TITLE
Fix: Pip error installing mod_wsgi in venv in Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -422,7 +422,12 @@ with open(os.path.join(os.path.dirname(__file__),
 PYTHON_VERSION = get_python_config('VERSION')
 
 if os.name == 'nt':
-    PYTHON_LIBDIR = sys.base_prefix
+    if hasattr(sys, 'real_prefix'):
+        PYTHON_LIBDIR = sys.real_prefix
+    elif hasattr(sys, 'base_prefix'):
+        PYTHON_LIBDIR = sys.base_prefix
+    else:
+        PYTHON_LIBDIR = get_python_config('BINDIR')
     PYTHON_LDFLAGS = []
     PYTHON_LDLIBS = ['%s/libs/python%s.lib' % (PYTHON_LIBDIR, PYTHON_VERSION),
             '%s/lib/libhttpd.lib' % WITH_WINDOWS_APACHE,

--- a/setup.py
+++ b/setup.py
@@ -422,11 +422,7 @@ with open(os.path.join(os.path.dirname(__file__),
 PYTHON_VERSION = get_python_config('VERSION')
 
 if os.name == 'nt':
-    if hasattr(sys, 'real_prefix'):
-        PYTHON_LIBDIR = sys.real_prefix
-    else:
-        PYTHON_LIBDIR = get_python_config('BINDIR')
-
+    PYTHON_LIBDIR = sys.base_prefix
     PYTHON_LDFLAGS = []
     PYTHON_LDLIBS = ['%s/libs/python%s.lib' % (PYTHON_LIBDIR, PYTHON_VERSION),
             '%s/lib/libhttpd.lib' % WITH_WINDOWS_APACHE,


### PR DESCRIPTION
Fixes https://github.com/GrahamDumpleton/mod_wsgi/issues/506

How: In `setup.py` always use base_prefix when locating libs as it points to the python installation wheter in a venv or not.