### PR TITLE
Setup CI with Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,30 @@
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: "Python ${{ matrix.python-version }}"
+    runs-on: "ubuntu-20.04"
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9"]
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "${{ matrix.python-version }}"
+      - name: Install extra dependencies
+        run: sudo apt install -y apache2-dev
+      - name: "Update pip"
+        run: python -m pip install --upgrade pip setuptools
+      - name: "Install tox dependencies"
+        run: python -m pip install --upgrade tox tox-gh-actions
+      - name: "Run tox for ${{ matrix.python-version }}"
+        run: "python -m tox -vvv"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,17 @@
 [tox]
-envlist = py26,py27,py33
+envlist = py26,py27,py33,py34,py35,py36,py37,py38,py39,py310
 
 [testenv]
 deps =
   newrelic
   mod_wsgi-metrics
+
+[gh-actions]
+python =
+    2.7: py27
+    3.5: py35
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310


### PR DESCRIPTION
Add rundimentary CI to test building of mod_wsgi most supported Python
versions. GHA offers Python 2.7, 3.5 to 3.10-beta.

Signed-off-by: Christian Heimes <cheimes@redhat.com>