### PR TITLE
Updated Windows Installer link

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,4 +22,4 @@ operating systems such as Linux and MacOS X see:
 
 If you are on Windows, you should instead use:
 
-  * https://github.com/GrahamDumpleton/mod_wsgi/blob/develop/win32/README.rst
+  * https://github.com/GrahamDumpleton/mod_wsgi/blob/develop/README.rst


### PR DESCRIPTION
- Updated link for Windows version of Installation as the old link was broken. (Most likely due to restructuring of the repository)