### PR TITLE
Added missing str() call on pathlib object

### DIFF
--- a/src/server/management/commands/runmodwsgi.py
+++ b/src/server/management/commands/runmodwsgi.py
@@ -92,7 +92,8 @@ class Command(BaseCommand):
 
         if options.get('working_directory') is None:
             if hasattr(settings, 'BASE_DIR'):
-                options['working_directory'] = settings.BASE_DIR
+                # support pathlib objects in Django settings.py
+                options['working_directory'] = str(settings.BASE_DIR)
             else:
                 settings_module_path = os.environ['DJANGO_SETTINGS_MODULE']
                 root_module_path = settings_module_path.split('.')[0]
@@ -117,14 +118,16 @@ class Command(BaseCommand):
                         # lists. We need to ensure we use the same type so
                         # that sorting of items in the lists works later.
 
+                        # support pathlib objects in Django settings.py
+                        static_root = str(settings.STATIC_ROOT)
                         if not url_aliases:
                             url_aliases.insert(0, (
                                     settings.STATIC_URL.rstrip('/') or '/',
-                                    settings.STATIC_ROOT))
+                                    static_root))
                         else:
                             url_aliases.insert(0, type(url_aliases[0])((
                                     settings.STATIC_URL.rstrip('/') or '/',
-                                    settings.STATIC_ROOT)))
+                                    static_root)))
 
         except AttributeError:
             pass


### PR DESCRIPTION
Fixes the following traceback
```
Traceback (most recent call last):
  File "/opt/app-root/src/manage.py", line 22, in <module>
     main()
  File "/opt/app-root/src/manage.py", line 18, in main
     execute_from_command_line(sys.argv)
   File "/opt/app-root/lib/python3.9/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
    utility.execute()
   File "/opt/app-root/lib/python3.9/site-packages/django/core/management/__init__.py", line 395, in execute
     self.fetch_command(subcommand).run_from_argv(self.argv)
   File "/opt/app-root/lib/python3.9/site-packages/django/core/management/base.py", line 330, in run_from_argv
     self.execute(*args, **cmd_options)
   File "/opt/app-root/lib/python3.9/site-packages/django/core/management/base.py", line 371, in execute
     output = self.handle(*args, **options)
   File "/opt/app-root/lib/python3.9/site-packages/mod_wsgi/server/management/commands/runmodwsgi.py", line 134, in handle
     options = mod_wsgi.server._cmd_setup_server(
   File "/opt/app-root/lib/python3.9/site-packages/mod_wsgi/server/__init__.py", line 3613, in _cmd_setup_server
    generate_apache_config(options)
   File "/opt/app-root/lib/python3.9/site-packages/mod_wsgi/server/__init__.py", line 1086, in generate_apache_config
if target.endswith('/') and path != '/':
AttributeError: 'PosixPath' object has no attribute 'endswith'
```