### PR TITLE
`ap_pool_cleanup_set_null` not found when compiling for Apache 2.2.34 and Python 3.10

### DIFF
--- a/src/server/mod_wsgi.c
+++ b/src/server/mod_wsgi.c
@@ -4777,9 +4777,11 @@ static const char *wsgi_add_script_alias(cmd_parms *cmd, void *mconfig,
         if (!wsgi_import_list) {
             wsgi_import_list = apr_array_make(cmd->pool, 20,
                                               sizeof(WSGIScriptFile));
+#if AP_SERVER_MINORVERSION_NUMBER > 2
             apr_pool_cleanup_register(cmd->pool, &wsgi_import_list,
                               ap_pool_cleanup_set_null,
                               apr_pool_cleanup_null);
+#endif
         }
 
         object = (WSGIScriptFile *)apr_array_push(wsgi_import_list);
@@ -5294,9 +5296,11 @@ static const char *wsgi_add_import_script(cmd_parms *cmd, void *mconfig,
     if (!wsgi_import_list) {
         wsgi_import_list = apr_array_make(cmd->pool, 20,
                                           sizeof(WSGIScriptFile));
+#if AP_SERVER_MINORVERSION_NUMBER > 2
         apr_pool_cleanup_register(cmd->pool, &wsgi_import_list,
                               ap_pool_cleanup_set_null,
                               apr_pool_cleanup_null);
+#endif
     }
 
     object = (WSGIScriptFile *)apr_array_push(wsgi_import_list);
@@ -7948,9 +7952,11 @@ static const char *wsgi_add_daemon_process(cmd_parms *cmd, void *mconfig,
     if (!wsgi_daemon_list) {
         wsgi_daemon_list = apr_array_make(cmd->pool, 20,
                                           sizeof(WSGIProcessGroup));
+#if AP_SERVER_MINORVERSION_NUMBER > 2
         apr_pool_cleanup_register(cmd->pool, &wsgi_daemon_list,
                               ap_pool_cleanup_set_null,
                               apr_pool_cleanup_null);
+#endif
     }
 
     entries = (WSGIProcessGroup *)wsgi_daemon_list->elts;
@@ -12917,11 +12923,11 @@ static int wsgi_hook_daemon_handler(conn_rec *c)
      * child process before request is proxied specifically to avoid
      * unecessarily passing the content across to the daemon process.
      */
-
+#if AP_SERVER_MINORVERSION_NUMBER > 2
     d = (core_dir_config *)ap_get_core_module_config(r->per_dir_config);
 
     d->limit_req_body = 0;
-
+#endif
     r->sent_bodyct = 0;
 
     r->read_length = 0;

--- a/src/server/mod_wsgi.c
+++ b/src/server/mod_wsgi.c
@@ -102,13 +102,6 @@ static apr_time_t volatile wsgi_restart_shutdown_time = 0;
 
 static apr_array_header_t *wsgi_import_list = NULL;
 
-static apr_status_t wsgi_cleanup_set_null(void *data_)
-{
-    void **ptr = (void **)data_;
-    *ptr = NULL;
-    return APR_SUCCESS;
-}
-
 static void *wsgi_create_server_config(apr_pool_t *p, server_rec *s)
 {
     WSGIServerConfig *config = NULL;
@@ -4785,7 +4778,7 @@ static const char *wsgi_add_script_alias(cmd_parms *cmd, void *mconfig,
             wsgi_import_list = apr_array_make(cmd->pool, 20,
                                               sizeof(WSGIScriptFile));
             apr_pool_cleanup_register(cmd->pool, &wsgi_import_list,
-                              wsgi_cleanup_set_null,
+                              ap_pool_cleanup_set_null,
                               apr_pool_cleanup_null);
         }
 
@@ -5302,7 +5295,7 @@ static const char *wsgi_add_import_script(cmd_parms *cmd, void *mconfig,
         wsgi_import_list = apr_array_make(cmd->pool, 20,
                                           sizeof(WSGIScriptFile));
         apr_pool_cleanup_register(cmd->pool, &wsgi_import_list,
-                              wsgi_cleanup_set_null,
+                              ap_pool_cleanup_set_null,
                               apr_pool_cleanup_null);
     }
 
@@ -7956,7 +7949,7 @@ static const char *wsgi_add_daemon_process(cmd_parms *cmd, void *mconfig,
         wsgi_daemon_list = apr_array_make(cmd->pool, 20,
                                           sizeof(WSGIProcessGroup));
         apr_pool_cleanup_register(cmd->pool, &wsgi_daemon_list,
-                              wsgi_cleanup_set_null,
+                              ap_pool_cleanup_set_null,
                               apr_pool_cleanup_null);
     }
 

--- a/src/server/mod_wsgi.c
+++ b/src/server/mod_wsgi.c
@@ -5302,7 +5302,7 @@ static const char *wsgi_add_import_script(cmd_parms *cmd, void *mconfig,
         wsgi_import_list = apr_array_make(cmd->pool, 20,
                                           sizeof(WSGIScriptFile));
         apr_pool_cleanup_register(cmd->pool, &wsgi_import_list,
-                              ap_pool_cleanup_set_null,
+                              wsgi_cleanup_set_null,
                               apr_pool_cleanup_null);
     }
 
@@ -7956,7 +7956,7 @@ static const char *wsgi_add_daemon_process(cmd_parms *cmd, void *mconfig,
         wsgi_daemon_list = apr_array_make(cmd->pool, 20,
                                           sizeof(WSGIProcessGroup));
         apr_pool_cleanup_register(cmd->pool, &wsgi_daemon_list,
-                              ap_pool_cleanup_set_null,
+                              wsgi_cleanup_set_null,
                               apr_pool_cleanup_null);
     }
 

--- a/src/server/mod_wsgi.c
+++ b/src/server/mod_wsgi.c
@@ -102,6 +102,13 @@ static apr_time_t volatile wsgi_restart_shutdown_time = 0;
 
 static apr_array_header_t *wsgi_import_list = NULL;
 
+static apr_status_t wsgi_cleanup_set_null(void *data_)
+{
+    void **ptr = (void **)data_;
+    *ptr = NULL;
+    return APR_SUCCESS;
+}
+
 static void *wsgi_create_server_config(apr_pool_t *p, server_rec *s)
 {
     WSGIServerConfig *config = NULL;
@@ -4778,7 +4785,7 @@ static const char *wsgi_add_script_alias(cmd_parms *cmd, void *mconfig,
             wsgi_import_list = apr_array_make(cmd->pool, 20,
                                               sizeof(WSGIScriptFile));
             apr_pool_cleanup_register(cmd->pool, &wsgi_import_list,
-                              ap_pool_cleanup_set_null,
+                              wsgi_cleanup_set_null,
                               apr_pool_cleanup_null);
         }
 


### PR DESCRIPTION
I'm compiling against Apache 2.2.34, Python 3.10 and mod_wsgi develop branch.

I get: 

    /opt_arxiv/apache/bin/apxs -c -I/opt_arxiv/python3.10/extlib/include -I/opt_arxiv/python3.10/include/python3.10 -DNDEBUG  -Wc,-g -Wc,-O2  src/server/mod_wsgi.c src/server/wsgi_*.c -L/opt_arxiv/python3.10/extlib/lib -Wl,--rpath=/opt_arxiv/python3.10/lib -Wl,--rpath=/opt_arxiv/python3.10/extlib/lib -L/opt_arxiv/python3.10/lib -L/opt_arxiv/python3.10/lib/python3.10/config  -lpython3.10 -lcrypt -lpthread -ldl  -lutil -lm -lm
    /opt_arxiv/apache2.2.34/build/libtool --silent --mode=compile gcc -prefer-pic   -DLINUX -D_REENTRANT -D_GNU_SOURCE -g -O2 -pthread -I/opt_arxiv/apache2.2.34/include  -I/opt_arxiv/apache2.2.34/include   -I/opt_arxiv/apache2.2.34/include  -g -O2 -I/opt_arxiv/python3.10/extlib/include -I/opt_arxiv/python3.10/include/python3.10 -DNDEBUG  -c -o src/server/mod_wsgi.lo 
    src/server/mod_wsgi.c && touch src/server/mod_wsgi.slo
    src/server/mod_wsgi.c: In function ‘wsgi_add_script_alias’:
    src/server/mod_wsgi.c:4765:31: error: ‘ap_pool_cleanup_set_null’ undeclared (first use in this function)
                               ap_pool_cleanup_set_null,

It looks like `ap_pool_cleanup_set_null` was added to Apache in 2.4.1. 

The code that adds this to `mod_wsgi.c` was added as part of this fix: https://github.com/GrahamDumpleton/mod_wsgi/issues/620

This PR disables use of some 2.4 function when compiled with 2.2.

(Previously this said:  This PR moves the trivial function `ap_pool_cleanup_set_null` into `mod_wsgi.c` so that it is available when compiling against Apache 2.2.)