### PR TITLE
Update WSGIScriptAliasMatch.rst

### DIFF
--- a/docs/configuration-directives/WSGIScriptAliasMatch.rst
+++ b/docs/configuration-directives/WSGIScriptAliasMatch.rst
@@ -28,6 +28,17 @@ doing redirects. This is because the substitution of the matched sub
 pattern from the left hand side back into the right hand side is often
 critical.
 
+If you are using WSGIScriptAliasMatch to pass to a wsgi handler, and you need
+to preserve the path.  You can do the following: 
+  
+  WSGIScriptAlias /api /var/www/mysite.com/apache/django.wsgi/api
+
+A more complicated example: 
+
+  WSGIScriptAliasMatch "^/(admin|files|photologue)" /projects/Media/wsgi_handler.py/$1
+  
+This will keep the URL match from being stripped off the URL by the time it reaches Django.
+
 If you think you need to use WSGIScriptAliasMatch, you probably don't
 really. If you really really think you need it, then check on the mod_wsgi
 mailing list about how to use it properly.

--- a/docs/configuration-directives/WSGIScriptAliasMatch.rst
+++ b/docs/configuration-directives/WSGIScriptAliasMatch.rst
@@ -28,16 +28,17 @@ doing redirects. This is because the substitution of the matched sub
 pattern from the left hand side back into the right hand side is often
 critical.
 
-If you are using WSGIScriptAliasMatch to pass to a wsgi handler, and you need
-to preserve the path.  You can do the following: 
+If you are using WSGIScriptAliasMatch to pass to a WSGI handler, and you
+need to preserve the path.  You can do the following::
   
   WSGIScriptAlias /api /var/www/mysite.com/apache/django.wsgi/api
 
-A more complicated example: 
+A more complicated example::
 
   WSGIScriptAliasMatch "^/(admin|files|photologue)" /projects/Media/wsgi_handler.py/$1
   
-This will keep the URL match from being stripped off the URL by the time it reaches Django.
+This will keep the URL match from being stripped off the URL by the time it
+reaches the WSGI application.
 
 If you think you need to use WSGIScriptAliasMatch, you probably don't
 really. If you really really think you need it, then check on the mod_wsgi


### PR DESCRIPTION
I have been searching for 2 days on this issue. I finally found the answer here: https://serverfault.com/questions/555955/can-i-configure-apache-mod-wsgi-so-that-the-alias-url-path-is-not-stripped-befor  It resolved my issue.  I would have been good to see it in the documentation.  I would have saved about 14 hours of banging my head against the wall.