### PR TITLE
docs: update code.google.com links

### DIFF
--- a/docs/release-notes/version-1.1.rst
+++ b/docs/release-notes/version-1.1.rst
@@ -12,7 +12,7 @@ Bug Fixes
 1. Fix bug which could result in processes crashing when multiple threads
 attempt to write to sys.stderr or sys.stdout at the same time. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=30
+  https://code.google.com/archive/p/modwsgi/issues/30
 
 Chance of this occuring was small, as was contingent on code writing out
 strings which contained an embedded newline but no terminating new line,
@@ -46,7 +46,7 @@ insert their own connection level input/output filters. This is needed as
 running WSGI applications in daemon processes where requests were arriving
 to Apache as HTTPS requests could cause daemon processes to crash. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=33
+  https://code.google.com/archive/p/modwsgi/issues/33
 
 This was only occuring for some HTTPS configurations, but not known what
 exactly was different about those configurations to cause the problem.
@@ -57,4 +57,4 @@ mod_logio module when loaded and when handling request in daemon process.
 This is needed to prevent core output filters calling this function and
 triggering a crash due to configuration for mod_logio not being setup. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=34
+  https://code.google.com/archive/p/modwsgi/issues/34

--- a/docs/release-notes/version-1.2.rst
+++ b/docs/release-notes/version-1.2.rst
@@ -25,7 +25,7 @@ the WSGI specification. In particular the specification says:
 In mod_wsgi when an iterable was returned from the application, the headers
 were being flushed even if the string was empty. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=35
+  https://code.google.com/archive/p/modwsgi/issues/35
 
 2. Calling start_response() a second time to supply exception information
 and status to replace prior response headers and status, was resulting in
@@ -33,7 +33,7 @@ a process crash when there had actually been response content sent and the
 existing response headers and status flushed and written back to the client.
 See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=36
+  https://code.google.com/archive/p/modwsgi/issues/36
 
 3. Added additional logging to highlight instance where WSGI script file was
 removed in between the time that Apache matched request to it and the WSGI
@@ -52,7 +52,7 @@ name would be wrong where the URL had repeating slashes in it after the
 leading portion of the URL which mapped to the mount point of the WSGI
 application. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=39
+  https://code.google.com/archive/p/modwsgi/issues/39
 
 In particular, for a URL with the repeating slash the application group
 name would have a trailing slash appended when it shouldn't. The
@@ -77,4 +77,4 @@ the default.
 daemon processes were not being caught properly. This was because mod_wsgi
 was wrongly blocking SIGCHLD signal. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=38
+  https://code.google.com/archive/p/modwsgi/issues/38

--- a/docs/release-notes/version-1.4.rst
+++ b/docs/release-notes/version-1.4.rst
@@ -16,7 +16,7 @@ status was being returned instead of a 500 error.
 2. Fix bug which was resulting in logging destined for !VirtualHost !ErrorLog
 going missing or ending up in main Apache error log.
 
-  http://code.google.com/p/modwsgi/issues/detail?id=79
+  https://code.google.com/archive/p/modwsgi/issues/79
 
 Features Added
 --------------

--- a/docs/release-notes/version-1.5.rst
+++ b/docs/release-notes/version-1.5.rst
@@ -14,6 +14,6 @@ being leaked in Apache parent process on a graceful restart. Also fixes
 problem where UNIX listener socket was left in filesystem on both graceful
 restart and graceful shutdown. For details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=95
+  https://code.google.com/archive/p/modwsgi/issues/95
 
 This is a backport of change from version 2.2 of mod_wsgi.

--- a/docs/release-notes/version-2.0.rst
+++ b/docs/release-notes/version-2.0.rst
@@ -73,7 +73,7 @@ just the script file will apply.
 
 For more details see:
 
-  http://code.google.com/p/modwsgi/wiki/ReloadingSourceCode
+  https://code.google.com/archive/p/modwsgi/wikis/ReloadingSourceCode
 
 2. When application is running in embedded mode, and WSGIApacheExtensions
 directive is set to On, then a Python CObject reference is added to the
@@ -93,7 +93,7 @@ The 'ap_swig_py' package has not yet been released and is still in
 development. The package can be obtained from the Subversion repository
 at:
 
-  https://bitbucket.org/grahamdumpleton/apswigpy/wiki/Home
+  https://bitbucket.org/grahamdumpleton/apswigpy/wikis/Home
 
 With the SWIG binding for the Apache API, the intention is that many of
 the internal features of Apache would then be available. For example::
@@ -269,7 +269,7 @@ the auth provider::
 
 For more details see:
 
-  http://code.google.com/p/modwsgi/wiki/AccessControlMechanisms
+  https://code.google.com/archive/p/modwsgi/wikis/AccessControlMechanisms
 
 4. When Apache 2.2 is being used, now possible to provide a script file
 containing a callable which returns the groups that a user is a member of.
@@ -305,7 +305,7 @@ and 'groups_for_user()' function with a sample as shown below::
 
 For more details see:
 
-  http://code.google.com/p/modwsgi/wiki/AccessControlMechanisms
+  https://code.google.com/archive/p/modwsgi/wikis/AccessControlMechanisms
 
 5. Implemented WSGIDispatchScript directive. This directive can be used
 to designate a script file in which can be optionally defined any of the
@@ -444,7 +444,7 @@ file itself.
 
 For more details see:
 
-  http://code.google.com/p/modwsgi/wiki/VirtualEnvironments
+  https://code.google.com/archive/p/modwsgi/wikis/VirtualEnvironments
 
 11. Added WSGIPythonEggs directive and corresponding 'python-eggs' option
 for WSGIDaemonProcess directive. These allow the location of the Python

--- a/docs/release-notes/version-2.1.rst
+++ b/docs/release-notes/version-2.1.rst
@@ -12,9 +12,9 @@ Bug Fixes
 1. Fix bug which was resulting in logging destined for !VirtualHost !ErrorLog
 going missing or ending up in main Apache error log.
 
-  http://code.google.com/p/modwsgi/issues/detail?id=79
+  https://code.google.com/archive/p/modwsgi/issues/79
 
 2. Fix bug where WSGI application returning None rather than valid iterable
 causes process to crash.
 
-  http://code.google.com/p/modwsgi/issues/detail?id=88
+  https://code.google.com/archive/p/modwsgi/issues/88

--- a/docs/release-notes/version-2.2.rst
+++ b/docs/release-notes/version-2.2.rst
@@ -15,7 +15,7 @@ Features Changed
 1. Use official way of setting process names on FreeBSD, NetBSD and OpenBSD.
 For details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=90
+  https://code.google.com/archive/p/modwsgi/issues/90
 
 This is a backport of change from version 3.0 of mod_wsgi.
 
@@ -26,23 +26,23 @@ Bug Fixes
 WSGIImportScript directive can cause Apache child processes to crash.
 For details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=91
+  https://code.google.com/archive/p/modwsgi/issues/91
 
 2. Fix bug where mod_wsgi daemon process startup could fail due to old stale
 UNIX listener socket file as described in:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=77
+  https://code.google.com/archive/p/modwsgi/issues/77
 
 3. Fix bug where listener socket file descriptors for daemon processes were
 being leaked in Apache parent process on a graceful restart. Also fixes
 problem where UNIX listener socket was left in filesystem on both graceful
 restart and graceful shutdown. For details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=95
+  https://code.google.com/archive/p/modwsgi/issues/95
 
 4. Fix bug where response was truncated when a null character appeared as
 first character in block of data being returned from wsgi.file_wrapper. Only
 occurred when code fell back to using iteration over supplied file like
 object, rather than optimised method such as sendfile().
 
-  http://code.google.com/p/modwsgi/issues/detail?id=100
+  https://code.google.com/archive/p/modwsgi/issues/100

--- a/docs/release-notes/version-2.3.rst
+++ b/docs/release-notes/version-2.3.rst
@@ -34,4 +34,4 @@ process to crash as corresponding arguments wouldn't have ben provided.
 
 For details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=90
+  https://code.google.com/archive/p/modwsgi/issues/90

--- a/docs/release-notes/version-2.4.rst
+++ b/docs/release-notes/version-2.4.rst
@@ -17,9 +17,9 @@ introduced by changes in mod_wsgi 2.3.
 directives at startup. This could later result in memory corruption and may
 account for problems seen with 'fopen()' errors. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=78
+  https://code.google.com/archive/p/modwsgi/issues/78
 
-  http://code.google.com/p/modwsgi/issues/detail?id=108
+  https://code.google.com/archive/p/modwsgi/issues/108
 
 3. Fix bug where Python interpreter not being destroyed correctly in Apache
 parent process on an Apache restart. This was resulting in slow memory leak
@@ -39,13 +39,13 @@ Python seem to occur for some versions of Python on particular platforms.
 
 For further details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=99
+  https://code.google.com/archive/p/modwsgi/issues/99
 
 4. Fix bug whereby POST requests where 100-continue was expected by client
 would see request content actually truncated and not be available to WSGI
 application if application running in daemon mode. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=121
+  https://code.google.com/archive/p/modwsgi/issues/121
 
 5. Fix bug where Apache optimisation related to keep alive connections can
 kick in when using wsgi.file_wrapper with result that if amount of data is
@@ -55,7 +55,7 @@ straight away but holding it over in case subsequent request on connection
 arrives. By then the file object used with wsgi.file_wrapper can have been
 closed and underlying file descriptor will not longer be valid. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=132
+  https://code.google.com/archive/p/modwsgi/issues/132
 
 6. Modify how daemon process shutdown request is detected such that no need
 to block signals in request threads. Doing this caused problems in
@@ -65,12 +65,12 @@ handler writes a character, with main thread performing a poll on pipe
 waiting for that character to know when to shutdown. For additional details
 see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=87
+  https://code.google.com/archive/p/modwsgi/issues/87
 
 7. Fix bug where excessive transient memory usage could occur when calling
 read() or readline() on wsgi.input with no argument. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=126
+  https://code.google.com/archive/p/modwsgi/issues/126
 
 Note that calling read() with no argument is actually a violation of WSGI
 specification and any application doing that is not a WSGI compliant
@@ -79,12 +79,12 @@ application.
 8. Fix bug where daemon process would crash if User/Group directives were
 not specified prior to WSGIDaemonProcess in Apache configuration file. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=40
+  https://code.google.com/archive/p/modwsgi/issues/40
 
 9. Fix bug whereby Python exception state wasn't being cleared correctly
 when error occurred in loading target of WSGIImportScript. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=117
+  https://code.google.com/archive/p/modwsgi/issues/117
 
 Features Changed
 ----------------
@@ -101,7 +101,7 @@ Features Added
 1. Added 'mod_wsgi.version' to WSGI environment passed to WSGI application.
 For details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=93
+  https://code.google.com/archive/p/modwsgi/issues/93
 
 2. Added 'process_group' and 'application_group' attributes to mod_wsgi module
 that is created within each Python interpreter instance. This allows code
@@ -110,7 +110,7 @@ running in a daemon process group and what it may be called. Similarly, can
 determine if running in first interpreter or some other sub interpreter.
 For details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=27
+  https://code.google.com/archive/p/modwsgi/issues/27
 
 3. Added closed and isatty attributes to Log object as well as close() method.
 For wsgi.errors these aren't required, but log object also used for stderr
@@ -119,17 +119,17 @@ stderr and stdout. The closed and isatty attributes always yield false and
 close() will raise a run time error indicating that log cannot be closed.
 For details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=82
+  https://code.google.com/archive/p/modwsgi/issues/82
 
 4. Apache scoreboard cleaned up when daemon processes first initialised to
 prevent any user code interfering with operation of Apache. For details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=104
+  https://code.google.com/archive/p/modwsgi/issues/104
 
 5. When running configure script, can now supply additional options for
 CPPFLAGS, LDFLAGS and LDLIBS through environment variables. For details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=107
+  https://code.google.com/archive/p/modwsgi/issues/107
 
 6. Better checking done on response headers and an explicit error will now
 be produce if name or value of response header contains an embedded newline.
@@ -138,7 +138,7 @@ when handing response in Apache child process. In embedded mode, could allow
 application to pass back malformed response headers to client. For details
 see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=81
+  https://code.google.com/archive/p/modwsgi/issues/81
 
 7: Ensure that SYSLIBS linker options from Python configuration used when
 linking mod_wsgi Apache module. This is now prooving necessary as some Apache
@@ -146,7 +146,7 @@ distributions are no longer linking system maths library and Python requires
 it. To avoid problem simply link against mod_wsgi Apache module and system
 libraries that Python needs. For details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=115
+  https://code.google.com/archive/p/modwsgi/issues/115
 
 8: Reorder sys.path after having called site.addsitedir() in WSGIPythonPath
 and python-path option for WSGIDaemonProcess. This ensures that newly added
@@ -155,7 +155,7 @@ standard directories. This in part avoids need to ensure --no-site-packages
 option used when creating virtual environments, as shouldn't have an issue
 with standard directories still overriding additions. For details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=112
+  https://code.google.com/archive/p/modwsgi/issues/112
 
 9. Update USER, USERNAME and LOGNAME environment variables if set in
 daemon process to be the actual user that the process runs as rather than
@@ -163,7 +163,7 @@ what may be inherited from Apache root process, which would typically be
 'root' or the user that executed 'sudo' to start Apache, if they hadn't
 used '-H' option to 'sudo'. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=129
+  https://code.google.com/archive/p/modwsgi/issues/129
 
 10. Build process now inserts what is believed to be the directory where
 Python shared library is installed, into the library search path before the
@@ -171,4 +171,4 @@ Python config directory. This should negate the need to ensure that Python
 shared library is also symlink into the config directory next to the static
 library as linkers would normally expect it. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=136
+  https://code.google.com/archive/p/modwsgi/issues/136

--- a/docs/release-notes/version-2.5.rst
+++ b/docs/release-notes/version-2.5.rst
@@ -8,7 +8,7 @@ Version 2.5 of mod_wsgi can be obtained from:
 
 For Windows binaries see:
 
-  http://code.google.com/p/modwsgi/wiki/InstallationOnWindows
+  https://code.google.com/archive/p/modwsgi/wikis/InstallationOnWindows
 
 Note that this release does not support Python 3.0. Python 3.0 will only be
 supported in mod_wsgi 3.0.
@@ -31,7 +31,7 @@ in compiler tools suite.
 
 For more details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=28
+  https://code.google.com/archive/p/modwsgi/issues/28
 
 2. Remove isatty from Log object used for stdout/stderr. It should have
 been a function and not an attribute. Even so, isatty() is not meant to be
@@ -42,4 +42,4 @@ not supply this, but the packages which were trying to use it.
 
 For more details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=146
+  https://code.google.com/archive/p/modwsgi/issues/146

--- a/docs/release-notes/version-2.6.rst
+++ b/docs/release-notes/version-2.6.rst
@@ -8,7 +8,7 @@ Version 2.6 of mod_wsgi can be obtained from:
 
 For Windows binaries see:
 
-  http://code.google.com/p/modwsgi/wiki/InstallationOnWindows
+  https://code.google.com/archive/p/modwsgi/wikis/InstallationOnWindows
 
 Note that this release does not support Python 3.0. Python 3.0 will only be
 supported in mod_wsgi 3.0.
@@ -25,7 +25,7 @@ run time. This was caused by '-W,-l' option prefix being dropped from '-F'
 option in LDFLAGS of Makefile and not reverted back when related changes
 undone. This would affect Python 2.3 through 2.5. For more details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=28
+  https://code.google.com/archive/p/modwsgi/issues/28
 
 2. Fixed build issue on MacOS X where incorrect Python framework found at
 run time. This was caused by '-L/-l' flags being used for versions of Python
@@ -39,7 +39,7 @@ particular setup this isn't working, then the '--disable-framework' option
 can be supplied to 'configure' script to force use of '-L/-l'. For more
 details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=28
+  https://code.google.com/archive/p/modwsgi/issues/28
 
 3. Fixed bug where was decrementing Python object reference count on NULL
 pointer, causing a crash. This was possibly only occuring in embedded mode
@@ -61,4 +61,4 @@ installed Apache header files. Do this as some Linux distributions build
 boxes do not actually have Apache executable itself installed, only the
 header files and apxs tool needed to build modules. For more details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=147
+  https://code.google.com/archive/p/modwsgi/issues/147

--- a/docs/release-notes/version-2.8.rst
+++ b/docs/release-notes/version-2.8.rst
@@ -14,4 +14,4 @@ when running 'configure' script are prefixed by '-Wc,' before being passed to
 'apxs' to build module. Without this 'apxs' will incorrectly interpret the
 compiler options. For more details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=166
+  https://code.google.com/archive/p/modwsgi/issues/166

--- a/docs/release-notes/version-3.0.rst
+++ b/docs/release-notes/version-3.0.rst
@@ -9,7 +9,7 @@ Version 3.0 of mod_wsgi can be obtained from:
 Precompiled Windows binaries for Apache 2.2 and Python 2.6 and 3.1 are also
 available from:
 
-  http://code.google.com/p/modwsgi/downloads/list
+  https://code.google.com/archive/p/modwsgi/downloads/list
 
 Note that mod_wsgi 3.0 was originally derived from mod_wsgi 2.0. It has
 though all changes from later releases in the 2.X branch. Thus also see:
@@ -27,7 +27,7 @@ Bug Fixes
 
 1. Fix bug with quoting of options to mod_wsgi directives as described in:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=55
+  https://code.google.com/archive/p/modwsgi/issues/55
 
 2. For any code not run in the first Python interpreter instance, thread
 local data was being thrown away at the end of the request, rather than
@@ -37,7 +37,7 @@ where data was intended to persist for the life of the process. The result
 was that any such data would have had to have been recreated on every
 request. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=120
+  https://code.google.com/archive/p/modwsgi/issues/120
 
 Features Changed
 ----------------
@@ -52,7 +52,7 @@ allow zero length read to propogate to Apache input filters when done, if
 the zero length read is the very first read against the input stream. For
 details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=52
+  https://code.google.com/archive/p/modwsgi/issues/52
 
 2. The WSGIImportScript can now appear inside of VirtualHost. However, there
 are now additional restrictions.
@@ -72,7 +72,7 @@ daemon process group defined in a VirtualHost context.
 
 For additional details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=110
+  https://code.google.com/archive/p/modwsgi/issues/110
 
 3. The restriction on accessing sys.stdin and sys.stdout has been lifted.
 This was originally done to promote the writing of portable WSGI code. In
@@ -104,7 +104,7 @@ of process reloading always used, unless of course WSGIScriptReloadig is Off
 and all reloading is disabled. Doesn't affect embedded mode where script
 reloading was always the only option. For details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=72
+  https://code.google.com/archive/p/modwsgi/issues/72
 
 2. There is no longer an attempt to set Content-Length header for a response
 if not supplied and iterable was a sequence of length 1. This was suggested
@@ -126,7 +126,7 @@ Features Added
 
 What constitutes support for Python 3.X is described in:
 
-  http://code.google.com/p/modwsgi/wiki/SupportForPython3X
+  https://code.google.com/archive/p/modwsgi/wikis/SupportForPython3X
 
 Note that Python 3.0 is not supported and cannot be used. You must use
 Python 3.1 or later as mod_wsgi relies on features only added in Python 3.1.
@@ -190,7 +190,7 @@ connection.
 
 For details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=29
+  https://code.google.com/archive/p/modwsgi/issues/29
 
 4. Added new 'chroot' option to WSGIDaemonProcess directive to force daemon
 process to run inside of a chroot environment.
@@ -231,7 +231,7 @@ pointers to what may need to be done for Debian/Ubuntu see article at:
 
 For details on this change also see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=106
+  https://code.google.com/archive/p/modwsgi/issues/106
 
 5. Added WSGIPy3kWarningFlag directive when Python 2.6 being used. This should
 be at server scope outside of any VirtualHost and will apply to whole server::
@@ -241,18 +241,18 @@ be at server scope outside of any VirtualHost and will apply to whole server::
 This should have same affect as -3 option to 'python' executable. For more
 details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=109
+  https://code.google.com/archive/p/modwsgi/issues/109
 
 6: Fix up how Python thread state API is used to avoid internal Python
 assertion error when Python compiled with Py_DEBUG preprocessor symbol.
 For details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=113
+  https://code.google.com/archive/p/modwsgi/issues/113
 
 7. Now allow chunked request content. Such content will be dechunked and
 available for reading by WSGI application. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=1
+  https://code.google.com/archive/p/modwsgi/issues/1
 
 To enable this feature, you must use::
 
@@ -283,7 +283,7 @@ using these your code will not be portable to other WSGI hosting mechanisms.
 8. Values for HTTP headers now passed in environment dictionary to access,
 authentication and authorisation hooks. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=69
+  https://code.google.com/archive/p/modwsgi/issues/69
 
 9. The flag wsgi.run_once is not set to True when running in daemon mode and
 both threads and maximum-requests is set to 1. With this configuration, are
@@ -339,7 +339,7 @@ less memory in total.
 
 For more details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=99
+  https://code.google.com/archive/p/modwsgi/issues/99
 
 11. If daemon process defined in virtual host which has its own error log,
 then associated stderr with that virtual hosts error log instead. This way
@@ -356,7 +356,7 @@ log and read data from the logs.
 as allowed for in CGI specification. Note though that this feature has only
 been implemented for mod_wsgi daemon mode. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=14
+  https://code.google.com/archive/p/modwsgi/issues/14
 
 14. Implement WSGIErrorOverride directive which when set to On will result
 in Apache error documents being used rather than those passed back by the
@@ -366,7 +366,7 @@ to the ProxyErrorOverride directive of Apache but for mod_wsgi only. Do note
 though that this feature has only been implemented for mod_wsgi daemon mode.
 See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=57
+  https://code.google.com/archive/p/modwsgi/issues/57
 
 15. Implement WSGIPythonWarnings directive as equivalent to the 'python'
 executable '-W' option. The directive can be used at global scope in Apache
@@ -383,7 +383,7 @@ or::
 
 For more details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=137
+  https://code.google.com/archive/p/modwsgi/issues/137
 
 16. Added cpu-time-limit option to WSGIDaemonProcess directive. This allows
 one to define a time in seconds which will be the maximum amount of cpu
@@ -392,7 +392,7 @@ daemon process restarted. The point of this is to provide some means of
 controlling potentially run away processes due to bad code that gets stuck
 in heavy processing loops. For more details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=21
+  https://code.google.com/archive/p/modwsgi/issues/21
 
 17. Added cpu-priority option to WSGIDaemonProcess directive. This allows
 one to adjust the CPU priority associated with processes in a daemon process
@@ -401,7 +401,7 @@ setpriority() function on your particular operating system accepts. Normally
 this is in the range of about -20 to 20, with 0 being normal. For more
 details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=142
+  https://code.google.com/archive/p/modwsgi/issues/142
 
 18. Added WSGIHandlerScript directive. This allows one to nominate a WSGI
 script file that should be executed as a handler for a specific file type

--- a/docs/release-notes/version-3.1.rst
+++ b/docs/release-notes/version-3.1.rst
@@ -18,7 +18,7 @@ when running 'configure' script are prefixed by '-Wc,' before being passed to
 'apxs' to build module. Without this 'apxs' will incorrectly interpret the
 compiler options. For more details see:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=166
+  https://code.google.com/archive/p/modwsgi/issues/166
 
 Features Changed
 ----------------
@@ -26,4 +26,4 @@ Features Changed
 1. Now give more explicit error message when compilation fails due to the
 Apache or Python developer header files not being installed. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=169
+  https://code.google.com/archive/p/modwsgi/issues/169

--- a/docs/release-notes/version-3.2.rst
+++ b/docs/release-notes/version-3.2.rst
@@ -18,7 +18,7 @@ the URL mapped was reported instead.
 causing all requests in daemon mode on a FreeBSD system to hang immediately
 upon Apache being started.
 
-  http://code.google.com/p/modwsgi/issues/detail?id=176
+  https://code.google.com/archive/p/modwsgi/issues/176
 
 Also use a distinct flag with condition variable in case condition variable
 is triggered even though condition not satisfied. This latter issue hasn't
@@ -35,9 +35,9 @@ associated with Apache server data structure to close. Code should always
 check that there is an error log to avoid crashing mod_wsgi daemon process
 on startup by operating on null pointer. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=178
+  https://code.google.com/archive/p/modwsgi/issues/178
 
 5. Code was not compiling with Apache 2.3. This is because ap_accept_lock_mech
 variable was removed. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=186
+  https://code.google.com/archive/p/modwsgi/issues/186

--- a/docs/release-notes/version-3.3.rst
+++ b/docs/release-notes/version-3.3.rst
@@ -12,23 +12,23 @@ Bug Fixes
 1. Inactivity timeout not triggered at correct time when occurs for first
 request after process is started. See
 
-  http://code.google.com/p/modwsgi/issues/detail?id=182
+  https://code.google.com/archive/p/modwsgi/issues/182
 
 2. Back off timer for failed connections to daemon process group wasn't
 working correctly and no delay on reconnect attempts was being applied. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=195
+  https://code.google.com/archive/p/modwsgi/issues/195
 
 3. Logging not appearing in Apache error log files when using daemon mode
 and have multiple virtual hosts against same server name. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=204
+  https://code.google.com/archive/p/modwsgi/issues/204
 
 4. Eliminate logging of !KeyError exception in threading module when processes
 are shutdown when using Python 2.6.5 or 3.1.2 or later. This wasn't indicating
 any real problem but was annoying all the same. See:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=197
+  https://code.google.com/archive/p/modwsgi/issues/197
 
 5. Fix potential for crash when logging error message resulting from failed
 group authorisation.
@@ -44,7 +44,7 @@ same user that daemon process runs. This will at least allow a request
 handled under ITK MPM to be directed to daemon process owned by same user
 as script. See issue:
 
-  http://code.google.com/p/modwsgi/issues/detail?id=187
+  https://code.google.com/archive/p/modwsgi/issues/187
 
 2. Add isatty() to log objects used for sys.stdout/sys.stderr and
 wsgi.errors. The Python documentation says 'If a file-like object is not


### PR DESCRIPTION
Hopefully fixes old `code.goggle.com` links as like what was found with #825 