### PR TITLE
python3 __next__

### DIFF
--- a/docs/user-guides/debugging-techniques.rst
+++ b/docs/user-guides/debugging-techniques.rst
@@ -313,8 +313,8 @@ follows::
             self.__ocontent.flush()
             return self.__write(data)
 
-        def next(self):
-            data = self.__iterable.next()
+        def __next__(self):
+            data = self.__iterable.__next__()
             self.__ocontent.write(data)
             self.__ocontent.flush()
             return data

--- a/docs/user-guides/debugging-techniques.rst
+++ b/docs/user-guides/debugging-techniques.rst
@@ -314,7 +314,7 @@ follows::
             return self.__write(data)
 
         def __next__(self):
-            data = self.__iterable.__next__()
+            data = next(self.__iterable)
             self.__ocontent.write(data)
             self.__ocontent.flush()
             return data


### PR DESCRIPTION
Current example doesn't work in Python 3.