### PR TITLE
Stop adding PYTHON_CFGDIR to LD_RUN_PATH and PYTHON_LDFLAGS if there is no libpython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -336,7 +336,8 @@ if os.name != 'nt':
     LD_RUN_PATH += ':' + ':'.join(LD_RUN_PATHS)
     LD_RUN_PATH = LD_RUN_PATH.lstrip(':')
 
-    os.environ['LD_RUN_PATH'] = LD_RUN_PATH
+    if LD_RUN_PATH:
+        os.environ['LD_RUN_PATH'] = LD_RUN_PATH
 
 # On MacOS X, recent versions of Apple's Apache do not support compiling
 # Apache modules with a target older than 10.8. This is because it

--- a/setup.py
+++ b/setup.py
@@ -300,19 +300,21 @@ else:
         if not os.path.exists(PYTHON_CFGDIR):
             PYTHON_CFGDIR = '%s-%s' % (PYTHON_CFGDIR, sys.platform)
 
-    PYTHON_LDFLAGS = ['-L%s' % PYTHON_CFGDIR]
+    PYTHON_LDFLAGS = []
     if PYTHON_LIBDIR != APXS_LIBDIR:
-        PYTHON_LDFLAGS.insert(0, '-L%s' % PYTHON_LIBDIR)
+        PYTHON_LDFLAGS.append('-L%s' % PYTHON_LIBDIR)
 
     PYTHON_LDLIBS = ['-lpython%s' % PYTHON_LDVERSION]
 
     if os.path.exists(os.path.join(PYTHON_LIBDIR,
             'libpython%s.a' % PYTHON_VERSION)):
         PYTHON_LDLIBS = ['-lpython%s' % PYTHON_VERSION]
+        PYTHON_LDFLAGS.append('-L%s' % PYTHON_CFGDIR)
 
     if os.path.exists(os.path.join(PYTHON_CFGDIR,
             'libpython%s.a' % PYTHON_VERSION)):
         PYTHON_LDLIBS = ['-lpython%s' % PYTHON_VERSION]
+        PYTHON_LDFLAGS.append('-L%s' % PYTHON_CFGDIR)
 
 # Create the final set of compilation flags to be used.
 
@@ -326,7 +328,9 @@ EXTRA_LINK_ARGS = PYTHON_LDFLAGS + PYTHON_LDLIBS
 LD_RUN_PATHS = []
 if os.name != 'nt':
     LD_RUN_PATH = os.environ.get('LD_RUN_PATH', '')
-    LD_RUN_PATHS = [PYTHON_CFGDIR]
+    LD_RUN_PATHS = []
+    if '-L%s' % PYTHON_CFGDIR in PYTHON_LDFLAGS:
+        LD_RUN_PATHS.append(PYTHON_CFGDIR)
     if PYTHON_LIBDIR != APXS_LIBDIR:
         LD_RUN_PATHS.insert(0, PYTHON_LIBDIR)
     LD_RUN_PATH += ':' + ':'.join(LD_RUN_PATHS)


### PR DESCRIPTION
The PYTHON_CFGDIR variable is more or less something like /usr/lib64/python3.12/config.

Not only does this directory not exist on Python 3.6+ (it is called differently), but there is no libpython.so in it.
Adding it to LD paths makes no difference.

I could fix up the way the path is determined,
but I decided not to touch this code not to break old use cases.

Instead, the directory is only added to LD paths when there is something relevant in it.

Fixes https://github.com/GrahamDumpleton/mod_wsgi/issues/872