### PR TITLE
Use Thread.daemon property rather than deprecated Thread.setDaemon

### DIFF
--- a/docs/user-guides/debugging-techniques.rst
+++ b/docs/user-guides/debugging-techniques.rst
@@ -1075,7 +1075,7 @@ going to need it because of a recurring problem::
                 pass
 
     _thread = threading.Thread(target=_monitor)
-    _thread.setDaemon(True)
+    _thread.daemon = True
 
     def _exiting():
         try:

--- a/docs/user-guides/reloading-source-code.rst
+++ b/docs/user-guides/reloading-source-code.rst
@@ -355,7 +355,7 @@ with how mod_wsgi works is shown below::
                 pass
 
     _thread = threading.Thread(target=_monitor)
-    _thread.setDaemon(True)
+    _thread.daemon = True
 
     def _exiting():
         try:

--- a/src/server/__init__.py
+++ b/src/server/__init__.py
@@ -1267,7 +1267,7 @@ def _monitor():
             pass
 
 _thread = threading.Thread(target=_monitor)
-_thread.setDaemon(True)
+_thread.daemon = True
 
 def _exiting():
     try:


### PR DESCRIPTION
The following deprecated warning is shown when importing mod_wsgi.server with -Wdefault option. [Thread.daemon](https://docs.python.org/2/library/threading.html#threading.Thread.daemon) property is introduced in Python 2.6.

```
$ /venv/py310/bin/python -Wdefault -c 'from mod_wsgi import server'
/venv/py310/lib/python3.10/site-packages/mod_wsgi/server/__init__.py:1270: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
  _thread.setDaemon(True)
```