### PR TITLE
Use $APACHE_RUN_DIR to derive default WSGISocketPrefix 

### DIFF
--- a/src/server/wsgi_server.c
+++ b/src/server/wsgi_server.c
@@ -78,7 +78,15 @@ WSGIServerConfig *newWSGIServerConfig(apr_pool_t *p)
     object->socket_prefix = NULL;
 
 #if defined(MOD_WSGI_WITH_DAEMONS)
-    object->socket_prefix = DEFAULT_REL_RUNTIMEDIR "/wsgi";
+#if defined(_GNU_SOURCE)
+#  define GETENV secure_getenv
+#else
+#  define GETENV getenv
+#endif
+    object->socket_prefix = GETENV("APACHE_RUN_DIR");
+    if (!object->socket_prefix)
+      object->socket_prefix = DEFAULT_REL_RUNTIMEDIR;
+    object->socket_prefix = apr_pstrcat(p, object->socket_prefix, "/wsgi", NULL);
     object->socket_prefix = ap_server_root_relative(p, object->socket_prefix);
 #endif
 


### PR DESCRIPTION
The default `WSGISocketPrefix` appears to be hard-coded to `DEFAULT_REL_RUNTIMEDIR "/wsgi"`, which (at least in my Ubuntu 24.04 / Apache 2.4.58 environment) evaluates to `/var/run/apache2/wsgi`.

However, this fails to set a correct prefix with non-standard Apache installations.  For example, when using a second Apache instance under Ubuntu, created via `sh /usr/share/doc/apache2/examples/setup-instance dev`, the run dir might be `/var/run/apache2-dev` instead.  This can be remedied by setting `WSGISocketPrefix /var/run/apache2-dev/wsgi` of course, but that should ideally be unneeded, since the run dir is knowable via the environment variable `$APACHE_RUN_DIR`.

This branch obviates the need to set `WSGISocketPrefix` merely because the run dir is in a non-default place, by checking that environment var first, before falling back to the hard-coded default.

P.S. thanks for your work on mod_wsgi; it is much appreciated.