### PR TITLE
Improve log message around interpreter attach/cleanup/destroy

### DIFF
--- a/src/server/wsgi_interp.c
+++ b/src/server/wsgi_interp.c
@@ -463,10 +463,16 @@ InterpreterObject *newInterpreterObject(const char *name)
          * be the case for the main Python interpreter.
          */
 
-        ap_log_error(APLOG_MARK, APLOG_INFO, 0, wsgi_server,
-                     "mod_wsgi (pid=%d): Attach interpreter '%s'.",
-                     getpid(), name);
-
+        if (*name) {
+            ap_log_error(APLOG_MARK, APLOG_INFO, 0, wsgi_server,
+                         "mod_wsgi (pid=%d): Attach interpreter '%s'.",
+                         getpid(), name);
+        }
+        else {
+            ap_log_error(APLOG_MARK, APLOG_INFO, 0, wsgi_server,
+                         "mod_wsgi (pid=%d): Attach main interpreter.",
+                         getpid());
+        }
         self->interp = interp;
         self->owner = 0;
 
@@ -1606,16 +1612,30 @@ static void Interpreter_dealloc(InterpreterObject *self)
 
     if (self->owner) {
         Py_BEGIN_ALLOW_THREADS
-        ap_log_error(APLOG_MARK, APLOG_INFO, 0, wsgi_server,
-                     "mod_wsgi (pid=%d): Destroy interpreter '%s'.",
-                     getpid(), self->name);
+        if (*self->name) {
+            ap_log_error(APLOG_MARK, APLOG_INFO, 0, wsgi_server,
+                         "mod_wsgi (pid=%d): Destroy interpreter '%s'.",
+                         getpid(), self->name);
+        }
+        else {
+            ap_log_error(APLOG_MARK, APLOG_INFO, 0, wsgi_server,
+                         "mod_wsgi (pid=%d): Destroy main interpreter.",
+                         getpid());
+        }
         Py_END_ALLOW_THREADS
     }
     else {
         Py_BEGIN_ALLOW_THREADS
-        ap_log_error(APLOG_MARK, APLOG_INFO, 0, wsgi_server,
-                     "mod_wsgi (pid=%d): Cleanup interpreter '%s'.",
-                     getpid(), self->name);
+        if (*self->name) {
+            ap_log_error(APLOG_MARK, APLOG_INFO, 0, wsgi_server,
+                         "mod_wsgi (pid=%d): Cleanup interpreter '%s'.",
+                         getpid(), self->name);
+        }
+        else {
+            ap_log_error(APLOG_MARK, APLOG_INFO, 0, wsgi_server,
+                         "mod_wsgi (pid=%d): Cleanup main interpreter.",
+                         getpid());
+        }
         Py_END_ALLOW_THREADS
     }
 


### PR DESCRIPTION
Improve log by saying whether a main interpreter is created or a named one (subinterpreter).

Output:
```
httpd-error.log:2026-02-15 01:15:17.587531 [pid: 47513, tid: 35046014976] [wsgi:info] mod_wsgi (pid=47513): Attach main interpreter.
httpd-error.log:2026-02-15 01:15:17.587837 [pid: 47514, tid: 35046014976] [wsgi:info] mod_wsgi (pid=47514): Attach main interpreter.
httpd-error.log:2026-02-15 01:15:17.587984 [pid: 47515, tid: 35046014976] [wsgi:info] mod_wsgi (pid=47515): Attach main interpreter.
httpd-error.log:2026-02-15 01:15:18.594050 [pid: 47519, tid: 35046014976] [wsgi:info] mod_wsgi (pid=47519): Attach main interpreter.
httpd-error.log:2026-02-15 01:16:20.537041 [pid: 47519, tid: 35046014976] [wsgi:info] mod_wsgi (pid=47519): Cleanup main interpreter.
httpd-error.log:2026-02-15 01:16:20.537069 [pid: 47513, tid: 35046014976] [wsgi:info] mod_wsgi (pid=47513): Cleanup main interpreter.
httpd-error.log:2026-02-15 01:16:20.537110 [pid: 47514, tid: 35046014976] [wsgi:info] mod_wsgi (pid=47514): Cleanup main interpreter.
httpd-error.log:2026-02-15 01:16:20.537823 [pid: 47515, tid: 35046014976] [wsgi:info] mod_wsgi (pid=47515): Cleanup main interpreter.
httpd-error.log:2026-02-15 01:16:21.570549 [pid: 47781, tid: 35056574464] [wsgi:info] mod_wsgi (pid=47781): Attach main interpreter.
httpd-error.log:2026-02-15 01:16:21.570815 [pid: 47782, tid: 35056574464] [wsgi:info] mod_wsgi (pid=47782): Attach main interpreter.
httpd-error.log:2026-02-15 01:16:21.570829 [pid: 47783, tid: 35056574464] [wsgi:info] mod_wsgi (pid=47783): Attach main interpreter.
httpd-error.log:2026-02-15 01:16:22.635472 [pid: 47785, tid: 35056574464] [wsgi:info] mod_wsgi (pid=47785): Attach main interpreter.
kona-dev.innomotics.net-error.log:2026-02-15 01:15:17.587854 [pid: 47512, tid: 35046014976] [wsgi:info] mod_wsgi (pid=47512): Attach main interpreter.
kona-dev.innomotics.net-error.log:2026-02-15 01:16:21.038598 [pid: 47512, tid: 35046014976] [wsgi:info] mod_wsgi (pid=47512): Cleanup main interpreter.
kona-dev.innomotics.net-error.log:2026-02-15 01:16:21.571154 [pid: 47780, tid: 35056574464] [wsgi:info] mod_wsgi (pid=47780): Attach main interpreter.
```

I intentionally haven't used the term subinterpreter because it would have been inconsistent with the rest of the log message. It needs to be done consistently throughout.

This fixes #942.